### PR TITLE
fix for minor error

### DIFF
--- a/DM_Utilities.lua
+++ b/DM_Utilities.lua
@@ -149,17 +149,7 @@ end
 --------------------------
 
 function DMUtils.playerInPvPMatch()
-  local eType = MatchingGameLib.GetMatchingGameType()
-
-  if eType then
-    local matches = {"Arena", "Battleground", "OpenArena", "RatedBattleground", "Warplot"}
-
-    for name, code in pairs(MatchingGameLib.MatchType) do
-      if eType == code and DMUtils.indexOf(matches, name) ~= nil then return true end
-    end
-  end
-
-  return false
+  return MatchingGameLib.IsInPvpGame()
 end
 
 --------------------------


### PR DESCRIPTION
on entering an instance (like dungeon, pvp, etc.) it would complain about this function that was removed in a recent patch:
MatchingGameLib.GetMatchingGameType()
in function DMUtils.playerInPvPMatch()

replaced it with a new api call that seems to do what the function was inteded for
